### PR TITLE
shortcut equals validation when obj is null in IdViewModel.Equals(obj…

### DIFF
--- a/Wavenet.Api.ViewModels.IdViewModel/IdViewModel.cs
+++ b/Wavenet.Api.ViewModels.IdViewModel/IdViewModel.cs
@@ -149,7 +149,7 @@ namespace Wavenet.Api.ViewModels
         public bool Equals(IdViewModel other) => this.Id == other?.Id;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => this.Equals(obj as IdViewModel);
+        public override bool Equals(object obj) => !(obj is null) && this.Equals(obj as IdViewModel);
 
         /// <inheritdoc />
         public override int GetHashCode() => this.Id.GetHashCode();


### PR DESCRIPTION
Ajout d'un shortcut is obj est null dans la méthode equals. C'est pas grand chose mais je pense que ça peut être bien de pas laissé se propager une égalité pour laquelle on peut déjà savoir qu'elle est false